### PR TITLE
Doc hosting

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,26 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master # update to match your development branch (master, main, dev, trunk, ...)
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.6'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 This repo is public so I can use GitHub Actions for free and learn about continuous integration (CI) while learning the ins and outs of proper Julia package development. None of this is really intended as a tutorial for others yet, and is just a reference for myself.
 
 ## My Resources
-* https://julialang.org/contribute/developing_package/ (Pretty good, but lacking the nitty gritty like proper order of operations with creating a repo. `.jl` is automatically added by some source?)
 
-# WIP Self Q&A
+* <https://julialang.org/contribute/developing_package/> (Pretty good, but lacking the nitty gritty like proper order of operations with creating a repo. `.jl` is automatically added by some source?)
+
+## WIP Self Q&A
+
 > Why use julia package mode and `dev` a package? What does this do?
 
 `dev`, or `develop` in julia Pkg mode `]` is a slick way to clone a public package and place it in your `user/.julia/dev` folder for you to develop and make changes to. The advantage here is that your environment now *uses that package*. You can check it using `]status`.
@@ -50,9 +52,9 @@ So it looks like VSCode just does it automatically and stores it in the `Project
 
 It doesn't. Instead, it looks at `jldoctest` snippets and tests them using `doctest(CoyLearnsPackageDev)` that I've included in `runtests.jl` according to the docs.
 
+## Initializing a new package
 
-# Initializing a new package
-1. Use `PkgTemplates` first. It needs to be added to the current environment if it hasn't been already (`]add PkgTemplates` in Julia REPL). 
+1. Use `PkgTemplates` first. It needs to be added to the current environment if it hasn't been already (`]add PkgTemplates` in Julia REPL).
 
 ```julia
 using PkgTemplates
@@ -68,27 +70,31 @@ t = Template(;
 
 t("CoyLearnsPackageDev")
 ```
+
 2. After running this code, there is a new package in `<user>/.julia/dev/`. Using GitHub Desktop, add a local repository from `<user>/.julia/dev/CoyLearnsPackageDev`.
 3. Now, you should see this repo added into GitHub desktop with a `.jl` added at the end of the name, like `CoyLearnsPackageDevelopment.jl`.
 4. If you try to push to remote, it yells at you and says that the repo doesn't exist. Go to github in the browser, and make a new repo with the same name as the package, *including* the `.jl`. Now, push to remote using GitHub desktop!
 5. Success! Now, we have a package whose folder name is `CoyLearnsPackageDevelopment` but a repository with a `.jl` at the end.
 
-# Organization 
+## Organization
+
 Code goes in `src/` and is stitched together in `packagename.jl` when a user does `using packagename`. The `include()` function brings in other files. User-accessible functions should be exported from the top level `packagename` module in `src/packagename.jl`.
 
 Likewise, unit tests are ran from `test/runtests.jl`. The same stitching is used for organization, see any large Julia package. The `@testset` macro just organizes the tests with a header description string:
-```julia 
+
+```julia
 @testset "description string" begin 
     @test this_function(3) == 6
 end
 ```
 
-# Documentation
+## Documentation
+
 It seems the vast majority of Julia packages manage their documentation with `Documenter.jl`. So, this'll what I'll learn and get accustomed to. I have a bit of experience from MuControl and using the Python analogue: Sphinx.
 
 The package initiation guide to get setup is fairly good and self explanatory. Two points though:
+
 1. When it asks you to use the terminal to run `julia make.jl`, just run the `make.jl` file inside of VSCode. This allows it to use the `Documenter.jl` that is in the project environment. This can also be done quickly by running the command `include("docs/make.jl")` in the terminal. (I like this the best)
 2. While setting things up locally, add the format kwarg `makedocs(sitename="My Documentation", format = Documenter.HTML(prettyurls = false))` to allow for easy local HTML browsing.
 
 It looks like `jldoctest`, or documentation tests, are most useful for keeping the documentation up to date and without error. This is in contrast to the tests in `test/` that minimizes code breakage during use.
-

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+CoyLearnsPackageDev = "af79404b-018b-44e4-a254-9ff3193b5e0c"
+
+[compat]
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,6 @@
 using Documenter, CoyLearnsPackageDev
 
-makedocs(sitename="CoyLearnsPackageDev.jl", format = Documenter.HTML(prettyurls = false))
+DocMeta.setdocmeta!(CoyLearnsPackageDev, :DocTestSetup, :(using CoyLearnsPackageDev); recursive=true)
+makedocs(sitename="CoyLearnsPackageDev.jl", format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"))
+
+deploydocs(repo = "github.com/czimm79/CoyLearnsPackageDev.jl.git")

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -14,7 +14,7 @@ end
 
 Compute `2x + 3y + 3`.
 
-# Example
+## Example
 ```jldoctest
 julia> super_function(3,2)
 15


### PR DESCRIPTION
Enabling GitHub actions to build the documentation and push it to `gh-pages`. Then, it can be hosted using GitHub pages.